### PR TITLE
Chore: Reduce file size

### DIFF
--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -1,4 +1,5 @@
-import firebase from "firebase";
+import { firebase } from "@firebase/app";
+import "@firebase/database";
 
 const devConfig = {
   apiKey: "AIzaSyCZSDNPsFaBbwgY0P3tySbPbUr1uD39hgI",


### PR DESCRIPTION
Import only what's needed in order to reduce the final JavaScript file size.
Firebase JS SDK comes with a raft of utility tools, only importing the necessary functions drastically reduces the overall file size to the application JS.

Resolves #24 & CMS7-385